### PR TITLE
feat: connect Next.js frontend to Go microservices backend

### DIFF
--- a/.c3/README.md
+++ b/.c3/README.md
@@ -1,0 +1,56 @@
+---
+id: c3-0
+c3-version: 4
+title: TicketBox
+goal: Solve the double booking problem under high concurrency (100K+ simultaneous users) with a scalable microservices architecture
+summary: Ticket booking platform with Go gRPC microservices backend, Next.js frontend, per-service PostgreSQL, and Kafka for async events
+---
+
+# TicketBox
+
+## Goal
+
+Solve the double booking problem under high concurrency (100K+ simultaneous users) with a scalable microservices architecture
+
+## Overview
+
+```mermaid
+graph TD
+    User([User Browser])
+    User --> FE[c3-6 Frontend<br/>Next.js :3000]
+    FE -->|/api proxy| GW[c3-1 Gateway<br/>Gin HTTP :8000]
+    GW -->|gRPC| US[c3-2 User Service<br/>:50051]
+    GW -->|gRPC| ES[c3-3 Event Service<br/>:50052]
+    GW -->|gRPC| BS[c3-4 Booking Service<br/>:50053]
+    GW -->|blacklist| Redis[(Redis :6379)]
+    BS -->|gRPC| ES
+    US --> DB_U[(PostgreSQL :5433)]
+    ES --> DB_E[(PostgreSQL :5434)]
+    BS --> DB_B[(PostgreSQL :5435)]
+    BS -->|outbox| Kafka{{Kafka :9092}}
+    NS[c3-5 Notification Service] -->|consume| Kafka
+    NS --> DB_N[(PostgreSQL :5436)]
+    PKG[c3-7 Shared Backend] -.->|used by| US & ES & BS & NS & GW
+```
+
+## Abstract Constraints
+
+| Constraint | Rationale | Affected Containers |
+|------------|-----------|---------------------|
+| No double bookings | Core business invariant — concurrent users must never book the same seat | c3-3, c3-4 |
+| Per-service database isolation | Independent scaling and data ownership | c3-2, c3-3, c3-4, c3-5 |
+| gRPC inter-service communication | Type-safe contracts, efficient binary protocol | c3-1, c3-2, c3-3, c3-4 |
+| JWT stateless authentication | Scalable auth without server-side sessions | c3-1, c3-2 |
+| 100K+ concurrent user support | System must handle peak load without data corruption | c3-3, c3-4 |
+
+## Containers
+
+| ID | Name | Boundary | Status | Responsibilities | Goal Contribution |
+|----|------|----------|--------|------------------|-------------------|
+| c3-1 | Gateway | service | active | HTTP→gRPC translation, JWT enforcement, CORS | Routes external HTTP requests to internal gRPC services with auth |
+| c3-2 | User Service | service | active | User identity, auth tokens, profiles | Manages authentication so booking flows have verified users |
+| c3-3 | Event Service | service | active | Event CRUD, ticket tier management, atomic availability | Enforces availability invariant via row-level locking |
+| c3-4 | Booking Service | service | active | Transactional booking creation, booking lifecycle | Orchestrates the booking transaction across services |
+| c3-5 | Notification Service | worker | active | Async event consumption, notification persistence | Decouples notification delivery from booking critical path |
+| c3-6 | Frontend | app | active | User interface, state management, API integration | Provides the user-facing booking experience |
+| c3-7 | Shared Backend | library | active | Config, DB helpers, Kafka, gRPC middleware, proto | Common infrastructure enabling consistent service behavior |

--- a/.c3/_index/structural.md
+++ b/.c3/_index/structural.md
@@ -1,0 +1,252 @@
+# C3 Structural Index
+<!-- hash: sha256:f1eac36347510c596e5698262b48da707ad1899f18087ab040f9d4a87630554a -->
+
+## adr-00000000-c3-adoption — C3 Architecture Documentation Adoption (adr)
+blocks: Goal ✓
+
+## c3-0 — ${PROJECT} (context)
+reverse deps: adr-00000000-c3-adoption, c3-1, c3-2, c3-3, c3-4, c3-5, c3-6, c3-7
+blocks: Abstract Constraints ✓, Containers ○, Goal ✓
+
+## c3-1 — gateway (container)
+context: c3-0
+reverse deps: c3-101, c3-102, c3-110, c3-111, c3-112, c3-113
+constraints from: c3-0
+blocks: Complexity Assessment ✓, Components ○, Goal ○, Responsibilities ✓
+
+## c3-101 — http-router (component)
+container: c3-1 | context: c3-0
+constraints from: c3-0, c3-1
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-102 — auth-middleware (component)
+container: c3-1 | context: c3-0
+constraints from: c3-0, c3-1
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-110 — auth-handler (component)
+container: c3-1 | context: c3-0
+constraints from: c3-0, c3-1
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-111 — event-handler (component)
+container: c3-1 | context: c3-0
+constraints from: c3-0, c3-1
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-112 — booking-handler (component)
+container: c3-1 | context: c3-0
+constraints from: c3-0, c3-1
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-113 — user-handler (component)
+container: c3-1 | context: c3-0
+constraints from: c3-0, c3-1
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-2 — user-service (container)
+context: c3-0
+reverse deps: c3-201, c3-202, c3-210, c3-211
+constraints from: c3-0
+blocks: Complexity Assessment ✓, Components ○, Goal ○, Responsibilities ✓
+
+## c3-201 — grpc-server (component)
+container: c3-2 | context: c3-0
+constraints from: c3-0, c3-2
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-202 — user-repository (component)
+container: c3-2 | context: c3-0
+constraints from: c3-0, c3-2
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-210 — auth-logic (component)
+container: c3-2 | context: c3-0
+constraints from: c3-0, c3-2
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-211 — profile-management (component)
+container: c3-2 | context: c3-0
+constraints from: c3-0, c3-2
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-3 — event-service (container)
+context: c3-0
+reverse deps: c3-301, c3-302, c3-310, c3-311
+constraints from: c3-0
+blocks: Complexity Assessment ✓, Components ○, Goal ○, Responsibilities ✓
+
+## c3-301 — grpc-server (component)
+container: c3-3 | context: c3-0
+constraints from: c3-0, c3-3
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-302 — event-repository (component)
+container: c3-3 | context: c3-0
+constraints from: c3-0, c3-3
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-310 — event-crud (component)
+container: c3-3 | context: c3-0
+constraints from: c3-0, c3-3
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-311 — ticket-availability (component)
+container: c3-3 | context: c3-0
+constraints from: c3-0, c3-3
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-4 — booking-service (container)
+context: c3-0
+reverse deps: c3-401, c3-402, c3-410, c3-411
+constraints from: c3-0
+blocks: Complexity Assessment ✓, Components ○, Goal ○, Responsibilities ✓
+
+## c3-401 — grpc-server (component)
+container: c3-4 | context: c3-0
+constraints from: c3-0, c3-4
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-402 — booking-repository (component)
+container: c3-4 | context: c3-0
+constraints from: c3-0, c3-4
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-410 — booking-creation (component)
+container: c3-4 | context: c3-0
+constraints from: c3-0, c3-4
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-411 — booking-management (component)
+container: c3-4 | context: c3-0
+constraints from: c3-0, c3-4
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-5 — notification-service (container)
+context: c3-0
+reverse deps: c3-501, c3-502, c3-510
+constraints from: c3-0
+blocks: Complexity Assessment ✓, Components ○, Goal ○, Responsibilities ✓
+
+## c3-501 — kafka-consumer (component)
+container: c3-5 | context: c3-0
+constraints from: c3-0, c3-5
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-502 — notification-repository (component)
+container: c3-5 | context: c3-0
+constraints from: c3-0, c3-5
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-510 — notification-processing (component)
+container: c3-5 | context: c3-0
+constraints from: c3-0, c3-5
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-6 — frontend (container)
+context: c3-0
+reverse deps: c3-601, c3-602, c3-603, c3-604, c3-610, c3-611, c3-612, c3-613, c3-614
+constraints from: c3-0
+blocks: Complexity Assessment ✓, Components ○, Goal ○, Responsibilities ✓
+
+## c3-601 — api-client (component)
+container: c3-6 | context: c3-0
+constraints from: c3-0, c3-6
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-602 — auth-state (component)
+container: c3-6 | context: c3-0
+constraints from: c3-0, c3-6
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-603 — booking-state (component)
+container: c3-6 | context: c3-0
+constraints from: c3-0, c3-6
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-604 — data-transformers (component)
+container: c3-6 | context: c3-0
+constraints from: c3-0, c3-6
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-610 — event-browsing (component)
+container: c3-6 | context: c3-0
+constraints from: c3-0, c3-6
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-611 — event-detail (component)
+container: c3-6 | context: c3-0
+constraints from: c3-0, c3-6
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-612 — checkout (component)
+container: c3-6 | context: c3-0
+constraints from: c3-0, c3-6
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-613 — my-tickets (component)
+container: c3-6 | context: c3-0
+constraints from: c3-0, c3-6
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-614 — auth-pages (component)
+container: c3-6 | context: c3-0
+constraints from: c3-0, c3-6
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-7 — shared-backend (container)
+context: c3-0
+reverse deps: c3-701, c3-702, c3-703, c3-704, c3-705
+constraints from: c3-0
+blocks: Complexity Assessment ✓, Components ○, Goal ○, Responsibilities ✓
+
+## c3-701 — config (component)
+container: c3-7 | context: c3-0
+constraints from: c3-0, c3-7
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-702 — database (component)
+container: c3-7 | context: c3-0
+constraints from: c3-0, c3-7
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-703 — kafka-pkg (component)
+container: c3-7 | context: c3-0
+constraints from: c3-0, c3-7
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-704 — grpc-middleware (component)
+container: c3-7 | context: c3-0
+constraints from: c3-0, c3-7
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## c3-705 — proto-generated (component)
+container: c3-7 | context: c3-0
+constraints from: c3-0, c3-7
+blocks: Container Connection ✓, Dependencies ✓, Goal ○, Related Refs ○
+
+## ref-concurrency-control — concurrency-control (ref)
+blocks: Choice ✓, Goal ✓, How ✓, Why ✓
+
+## ref-data-shape-mapping — data-shape-mapping (ref)
+blocks: Choice ✓, Goal ✓, How ✓, Why ✓
+
+## ref-grpc-service-structure — grpc-service-structure (ref)
+blocks: Choice ✓, Goal ✓, How ✓, Why ✓
+
+## ref-jwt-auth-flow — jwt-auth-flow (ref)
+blocks: Choice ✓, Goal ✓, How ✓, Why ✓
+
+## ref-outbox-pattern — outbox-pattern (ref)
+blocks: Choice ✓, Goal ✓, How ✓, Why ✓
+
+## ref-repository-pattern — repository-pattern (ref)
+blocks: Choice ✓, Goal ✓, How ✓, Why ✓
+
+## Ref Map
+ref-concurrency-control
+ref-data-shape-mapping
+ref-grpc-service-structure
+ref-jwt-auth-flow
+ref-outbox-pattern
+ref-repository-pattern

--- a/.c3/adr/adr-00000000-c3-adoption.md
+++ b/.c3/adr/adr-00000000-c3-adoption.md
@@ -1,0 +1,251 @@
+---
+id: adr-00000000-c3-adoption
+c3-version: 4
+title: C3 Architecture Documentation Adoption
+type: adr
+status: implemented
+date: 20260311
+affects: [c3-0]
+---
+
+# C3 Architecture Documentation Adoption
+
+## Goal
+
+Adopt C3 methodology for booking.
+
+<!--
+EXIT CRITERIA (all must be true to mark implemented):
+- All containers documented with Goal Contribution
+- All components documented with Container Connection
+- Refs extracted for repeated patterns
+- Integrity checks pass
+- Audit passes
+-->
+
+## Workflow
+
+```mermaid
+flowchart TD
+    GOAL([Goal]) --> S0
+
+    subgraph S0["Stage 0: Inventory"]
+        S0_DISCOVER[Discover codebase] --> S0_ASK{Gaps?}
+        S0_ASK -->|Yes| S0_SOCRATIC[Socratic] --> S0_DISCOVER
+        S0_ASK -->|No| S0_LIST[List items + diagram]
+    end
+
+    S0_LIST --> G0{Inventory complete?}
+    G0 -->|No| S0_DISCOVER
+    G0 -->|Yes| S1
+
+    subgraph S1["Stage 1: Details"]
+        S1_CONTAINER[Per container] --> S1_INT[Internal comp]
+        S1_CONTAINER --> S1_LINK[Linkage comp]
+        S1_INT --> S1_REF[Extract refs]
+        S1_LINK --> S1_REF
+        S1_REF --> S1_ASK{Questions?}
+        S1_ASK -->|Yes| S1_SOCRATIC[Socratic] --> S1_CONTAINER
+        S1_ASK -->|No| S1_NEXT{More?}
+        S1_NEXT -->|Yes| S1_CONTAINER
+    end
+
+    S1_NEXT -->|No| G1{Fix inventory?}
+    G1 -->|Yes| S0_DISCOVER
+    G1 -->|No| S2
+
+    subgraph S2["Stage 2: Finalize"]
+        S2_CHECK[Integrity checks]
+    end
+
+    S2_CHECK --> G2{Issues?}
+    G2 -->|Inventory| S0_DISCOVER
+    G2 -->|Detail| S1_CONTAINER
+    G2 -->|None| DONE([Implemented])
+```
+
+---
+
+## Stage 0: Inventory
+
+<!--
+DISCOVER everything first. Don't document yet.
+- Auto-discover codebase structure
+- Use AskUserQuestion for gaps
+- Identify refs that span across items
+- Exit: All items listed with arguments for templates
+-->
+
+### Context Discovery
+
+| Arg | Value |
+|-----|-------|
+| PROJECT | TicketBox |
+| GOAL | Solve the double booking problem under high concurrency (100K+ simultaneous users) with a scalable microservices architecture |
+| SUMMARY | Ticket booking platform with Go gRPC microservices backend, Next.js frontend, per-service PostgreSQL, and Kafka for async events |
+
+### Abstract Constraints
+
+| Constraint | Rationale | Affected Containers |
+|------------|-----------|---------------------|
+| No double bookings | Core business invariant — two users must never book the same seat | c3-3-event-service, c3-4-booking-service |
+| Per-service database isolation | Each service owns its data to enable independent scaling | c3-2-user-service, c3-3-event-service, c3-4-booking-service, c3-5-notification-service |
+| gRPC for inter-service communication | Type-safe contracts, efficient binary protocol for internal traffic | All backend services |
+| JWT stateless auth | Scalable authentication without server-side sessions | c3-1-gateway, c3-2-user-service |
+| 100K+ concurrent user support | System must handle peak load without data corruption | c3-3-event-service, c3-4-booking-service |
+
+### Container Discovery
+
+| N | CONTAINER_NAME | BOUNDARY | GOAL | SUMMARY |
+|---|----------------|----------|------|---------|
+| 1 | gateway | service | Route HTTP requests to backend gRPC services with auth enforcement | Gin HTTP gateway (:8000) translating REST to gRPC, JWT validation via middleware, Redis token blacklist |
+| 2 | user-service | service | Manage user identity, authentication, and profiles | gRPC service (:50051) handling register/login/refresh/logout and profile CRUD, DB: ticketbox_user |
+| 3 | event-service | service | Manage events and enforce ticket availability with row-level locking | gRPC service (:50052) with atomic availability updates via SELECT FOR UPDATE, DB: ticketbox_event |
+| 4 | booking-service | service | Create and manage bookings transactionally with concurrency control | gRPC service (:50053) coordinating with event-service for availability, DB: ticketbox_booking |
+| 5 | notification-service | worker | Consume booking events and persist notifications | Kafka consumer (no gRPC port), DB: ticketbox_notification |
+| 6 | frontend | app | Provide the user-facing booking experience with offline fallback | Next.js 16 App Router (:3000) with auth/booking contexts, API proxy to gateway |
+| 7 | shared-backend | library | Provide common infrastructure used by all backend services | Go packages: config, database, kafka, gRPC middleware, generated protobuf code |
+
+### Component Discovery (Brief)
+
+| N | NN | COMPONENT_NAME | CATEGORY | GOAL | SUMMARY |
+|---|----|----|----------|------|---------|
+| 1 | 01 | http-router | foundation | Define HTTP routes and middleware chain | Gin router setup with CORS, auth, admin middleware |
+| 1 | 02 | auth-middleware | foundation | Validate JWT tokens and enforce auth | JWT parsing, Redis blacklist check, role extraction |
+| 1 | 10 | auth-handler | feature | Expose auth endpoints via HTTP | Register/login/refresh/logout handlers |
+| 1 | 11 | event-handler | feature | Expose event endpoints via HTTP | CRUD events, availability queries |
+| 1 | 12 | booking-handler | feature | Expose booking endpoints via HTTP | Create/get/list/cancel bookings |
+| 1 | 13 | user-handler | feature | Expose user profile endpoints via HTTP | Get/update profile |
+| 2 | 01 | user-grpc-server | foundation | Implement UserService gRPC interface | Protobuf service implementation |
+| 2 | 02 | user-repository | foundation | Persist user data in PostgreSQL | PGX-based CRUD with password hashing |
+| 2 | 10 | auth-logic | feature | Handle authentication flows | Register, login, JWT generation, refresh tokens |
+| 2 | 11 | profile-management | feature | Handle profile operations | Get/update user profile |
+| 3 | 01 | event-grpc-server | foundation | Implement EventService gRPC interface | Protobuf service implementation |
+| 3 | 02 | event-repository | foundation | Persist event data with row-level locking | PGX-based CRUD with SELECT FOR UPDATE |
+| 3 | 10 | event-crud | feature | Manage event lifecycle | Create/read/update/delete events and tiers |
+| 3 | 11 | ticket-availability | feature | Enforce atomic availability updates | Row-level locking or optimistic versioning |
+| 4 | 01 | booking-grpc-server | foundation | Implement BookingService gRPC interface | Protobuf service implementation |
+| 4 | 02 | booking-repository | foundation | Persist booking data with outbox | PGX-based CRUD with outbox table writes |
+| 4 | 10 | booking-creation | feature | Orchestrate transactional booking creation | Calls event-service for availability, creates booking |
+| 4 | 11 | booking-management | feature | Handle booking queries and cancellation | Get/list/cancel bookings |
+| 5 | 01 | kafka-consumer | foundation | Consume events from Kafka topics | Kafka consumer group setup |
+| 5 | 02 | notification-repository | foundation | Persist notifications in PostgreSQL | PGX-based notification storage |
+| 5 | 10 | notification-processing | feature | Process booking events into notifications | Transform Kafka messages to stored notifications |
+| 6 | 01 | api-client | foundation | HTTP client with JWT token management | Singleton client, auto-refresh on 401, proxy via Next.js rewrites |
+| 6 | 02 | auth-state | foundation | Global authentication state management | AuthProvider context with login/register/logout |
+| 6 | 03 | booking-state | foundation | Global event and cart state management | BookingProvider context with mock data fallback |
+| 6 | 04 | data-transformers | foundation | Convert API types to frontend types | cents→dollars, snake_case→camelCase, date formatting |
+| 6 | 10 | event-browsing | feature | Display event listings and search | Home page hero, event grid, filtering |
+| 6 | 11 | event-detail | feature | Show event detail and seat selection | Event page, interactive SVG venue map |
+| 6 | 12 | checkout | feature | Cart and purchase flow | Checkout page, booking creation |
+| 6 | 13 | my-tickets | feature | Display purchased ticket history | Ticket listing with status |
+| 6 | 14 | auth-pages | feature | Login and registration forms | Login/register pages |
+| 7 | 01 | config | foundation | Environment-based configuration loading | Viper config with SERVICE_NAME, ports, DB URLs |
+| 7 | 02 | database | foundation | PostgreSQL connection pool helper | PGX pool creation and management |
+| 7 | 03 | kafka-pkg | foundation | Kafka producer and consumer utilities | Shared producer/consumer setup |
+| 7 | 04 | grpc-middleware | foundation | gRPC logging interceptor | Unary interceptor with structured logging |
+| 7 | 05 | proto-generated | foundation | Generated protobuf Go code | Service stubs for user/event/booking |
+
+### Ref Discovery
+
+| SLUG | TITLE | GOAL | Scope | Applies To |
+|------|-------|------|-------|------------|
+| grpc-service-structure | gRPC Service Structure | Enforce consistent service layout | backend | c3-2, c3-3, c3-4, c3-5 |
+| repository-pattern | Repository Pattern | Separate data access from business logic | backend | All backend services |
+| jwt-auth-flow | JWT Authentication Flow | Consistent auth across frontend and gateway | system | c3-1, c3-2, c3-6 |
+| data-shape-mapping | Data Shape Mapping | Transform between API and frontend types | system | c3-1, c3-6, c3-7 |
+| concurrency-control | Concurrency Control | Prevent double bookings under high load | backend | c3-3, c3-4 |
+| outbox-pattern | Outbox Pattern | Reliable async event publishing | backend | c3-4, c3-5 |
+| mock-data-fallback | Mock Data Fallback | Enable frontend development without backend | frontend | c3-6 |
+
+### Overview Diagram
+
+```mermaid
+graph TD
+    User([User Browser])
+
+    User --> FE[c3-6 Frontend<br/>Next.js :3000]
+    FE -->|/api proxy| GW[c3-1 Gateway<br/>Gin HTTP :8000]
+
+    GW -->|gRPC| US[c3-2 User Service<br/>:50051]
+    GW -->|gRPC| ES[c3-3 Event Service<br/>:50052]
+    GW -->|gRPC| BS[c3-4 Booking Service<br/>:50053]
+    GW -->|blacklist| Redis[(Redis :6379)]
+
+    BS -->|gRPC| ES
+
+    US --> DB_U[(PostgreSQL<br/>:5433)]
+    ES --> DB_E[(PostgreSQL<br/>:5434)]
+    BS --> DB_B[(PostgreSQL<br/>:5435)]
+
+    BS -->|outbox| Kafka{{Kafka :9092}}
+    NS[c3-5 Notification Service] -->|consume| Kafka
+    NS --> DB_N[(PostgreSQL<br/>:5436)]
+
+    PKG[c3-7 Shared Backend<br/>pkg/] -.->|used by| US
+    PKG -.->|used by| ES
+    PKG -.->|used by| BS
+    PKG -.->|used by| NS
+    PKG -.->|used by| GW
+```
+
+### Gate 0
+
+- [x] Context args filled
+- [x] Abstract Constraints identified
+- [x] All containers identified with args (including BOUNDARY)
+- [x] All components identified (brief) with args and category
+- [x] Cross-cutting refs identified
+- [x] Overview diagram generated
+
+---
+
+## Stage 1: Details
+
+All 7 container READMEs, 35 component docs, and 7 ref docs created and filled.
+
+### Gate 1
+
+- [x] All container README.md created
+- [x] All component docs created
+- [x] All refs documented
+- [x] No new items discovered
+
+---
+
+## Stage 2: Finalize
+
+### Code-Map
+
+- [x] Code-map scaffolded and patterns filled
+- [x] Coverage: 100% (59 mapped, 91 excluded, 0 unmapped)
+
+### Integrity Checks
+
+| Check | Status |
+|-------|--------|
+| Context ↔ Container (all 7 containers listed in c3-0) | [x] |
+| Container ↔ Component (all 35 components in container READMEs) | [x] |
+| Component ↔ Component (dependencies documented) | [x] |
+| * ↔ Refs (7 refs cited in component Related Refs) | [x] |
+
+### Gate 2
+
+- [x] All integrity checks pass
+- [x] Coverage at 100%
+- [x] c3x list shows complete topology
+
+---
+
+## Exit
+
+Status: `implemented`
+
+## Audit Record
+
+| Phase | Date | Notes |
+|-------|------|-------|
+| Adopted | 20260311 | Initial C3 structure created |
+| Inventory | 20260311 | 7 containers, 35 components, 7 refs discovered |
+| Details | 20260311 | All docs filled with goals, dependencies, code refs |
+| Finalized | 20260311 | Code-map 100% coverage, structural checks pass |

--- a/.c3/c3-1-gateway/README.md
+++ b/.c3/c3-1-gateway/README.md
@@ -1,0 +1,54 @@
+---
+id: c3-1
+c3-version: 4
+title: gateway
+type: container
+boundary: service
+parent: c3-0
+goal: Route external HTTP requests to internal gRPC services with authentication enforcement
+summary: Gin HTTP gateway translating REST to gRPC with JWT validation and Redis token blacklist
+---
+
+# gateway
+
+## Goal
+
+Route external HTTP requests to internal gRPC services with authentication enforcement
+
+## Responsibilities
+
+- HTTP→gRPC translation for all backend service endpoints
+- JWT authentication enforcement on protected routes
+- CORS policy management for frontend access
+- Request/response mapping between HTTP and gRPC formats
+
+## Complexity Assessment
+
+**Level:** moderate
+**Why:** Multiple middleware layers, gRPC client management, error translation
+
+## Components
+
+| ID | Name | Category | Status | Goal Contribution |
+|----|------|----------|--------|-------------------|
+| c3-101 | http-router | foundation | active | Defines route structure and middleware chain for all API endpoints |
+| c3-102 | auth-middleware | foundation | active | Enforces JWT auth and Redis blacklist on protected routes |
+| c3-110 | auth-handler | feature | active | Exposes register/login/refresh/logout via HTTP |
+| c3-111 | event-handler | feature | active | Exposes event CRUD and availability via HTTP |
+| c3-112 | booking-handler | feature | active | Exposes booking create/get/list/cancel via HTTP |
+| c3-113 | user-handler | feature | active | Exposes profile get/update via HTTP |
+
+## Layer Constraints
+
+This container operates within these boundaries:
+
+**MUST:**
+- Coordinate components within its boundary
+- Define how context linkages are fulfilled internally
+- Own its technology stack decisions
+
+**MUST NOT:**
+- Define system-wide policies (context responsibility)
+- Implement business logic directly (component responsibility)
+- Bypass refs for cross-cutting concerns
+- Orchestrate other containers (context responsibility)

--- a/.c3/c3-1-gateway/c3-101-http-router.md
+++ b/.c3/c3-1-gateway/c3-101-http-router.md
@@ -1,0 +1,54 @@
+---
+id: c3-101
+c3-version: 4
+title: http-router
+type: component
+category: foundation
+parent: c3-1
+goal: Define HTTP route structure and middleware chain for all API endpoints
+summary: Gin router with CORS, auth, and admin middleware wiring
+---
+
+# http-router
+
+## Goal
+
+Define HTTP route structure and middleware chain for all API endpoints.
+
+## Container Connection
+
+Without routing, no HTTP requests reach any handler -- the gateway cannot function. This component maps every REST endpoint to its handler and applies the correct middleware (CORS, auth, admin) per route group, fulfilling the gateway's role as the single HTTP entry point for all backend services.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | auth-middleware | c3-102 for JWT enforcement on protected routes |
+| OUT (provides) | Structured routes | To all handler components (c3-110 through c3-113) |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `backend/services/gateway/internal/router/router.go` | Route definitions and middleware setup |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-grpc-service-structure | Follows the gateway variant of the service pattern |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-1-gateway/c3-102-auth-middleware.md
+++ b/.c3/c3-1-gateway/c3-102-auth-middleware.md
@@ -1,0 +1,56 @@
+---
+id: c3-102
+c3-version: 4
+title: auth-middleware
+type: component
+category: foundation
+parent: c3-1
+goal: Validate JWT tokens and enforce authentication on protected routes
+summary: JWT parsing middleware with Redis token blacklist integration
+---
+
+# auth-middleware
+
+## Goal
+
+Validate JWT tokens and enforce authentication on protected routes.
+
+## Container Connection
+
+Without auth middleware, protected endpoints would be publicly accessible. This component intercepts requests before they reach handlers, verifying JWT validity and checking the Redis blacklist for revoked tokens. It injects authenticated user context that downstream handlers depend on.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Redis connection | Token blacklist store for revoked tokens |
+| IN (uses) | JWT secret | From config (c3-701) for token verification |
+| OUT (provides) | Authenticated user context | To all protected route handlers |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `backend/services/gateway/internal/middleware/auth.go` | JWT validation and blacklist check |
+| `backend/services/gateway/internal/middleware/cors.go` | CORS policy configuration |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-jwt-auth-flow | Implements the gateway side of JWT validation |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-1-gateway/c3-110-auth-handler.md
+++ b/.c3/c3-1-gateway/c3-110-auth-handler.md
@@ -1,0 +1,54 @@
+---
+id: c3-110
+c3-version: 4
+title: auth-handler
+type: component
+category: feature
+parent: c3-1
+goal: Expose authentication endpoints via HTTP REST
+summary: Handlers translating HTTP auth requests to User Service gRPC calls
+---
+
+# auth-handler
+
+## Goal
+
+Expose authentication endpoints via HTTP REST.
+
+## Container Connection
+
+Enables user registration and login through the HTTP API. Without this handler, clients have no way to authenticate with the platform. Translates HTTP request/response formats to and from the User Service gRPC protocol.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | User Service gRPC client | For register, login, refresh, logout operations |
+| OUT (provides) | HTTP auth responses | JWT tokens and user data to API consumers |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `backend/services/gateway/internal/handler/auth_handler.go` | Register/login/refresh/logout handlers |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-jwt-auth-flow | Returns JWT tokens from auth operations |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-1-gateway/c3-111-event-handler.md
+++ b/.c3/c3-1-gateway/c3-111-event-handler.md
@@ -1,0 +1,54 @@
+---
+id: c3-111
+c3-version: 4
+title: event-handler
+type: component
+category: feature
+parent: c3-1
+goal: Expose event management endpoints via HTTP REST
+summary: Handlers translating HTTP event requests to Event Service gRPC calls
+---
+
+# event-handler
+
+## Goal
+
+Expose event management endpoints via HTTP REST.
+
+## Container Connection
+
+Enables event browsing and management through the HTTP API. Without this handler, no client can discover or manage events. Translates HTTP request/response formats to and from the Event Service gRPC protocol, converting protobuf messages to JSON.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Event Service gRPC client | For event CRUD and availability queries |
+| OUT (provides) | HTTP event responses | JSON event data to API consumers |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `backend/services/gateway/internal/handler/event_handler.go` | Event CRUD and availability handlers |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-data-shape-mapping | Translates protobuf to JSON response format |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-1-gateway/c3-112-booking-handler.md
+++ b/.c3/c3-1-gateway/c3-112-booking-handler.md
@@ -1,0 +1,54 @@
+---
+id: c3-112
+c3-version: 4
+title: booking-handler
+type: component
+category: feature
+parent: c3-1
+goal: Expose booking endpoints via HTTP REST
+summary: Handlers translating HTTP booking requests to Booking Service gRPC calls
+---
+
+# booking-handler
+
+## Goal
+
+Expose booking endpoints via HTTP REST.
+
+## Container Connection
+
+Enables ticket purchasing through the HTTP API. Without this handler, users cannot create, view, or cancel bookings. Translates HTTP request/response formats to and from the Booking Service gRPC protocol.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Booking Service gRPC client | For create, get, list, cancel booking operations |
+| OUT (provides) | HTTP booking responses | JSON booking data to API consumers |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `backend/services/gateway/internal/handler/booking_handler.go` | Create/get/list/cancel booking handlers |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-data-shape-mapping | Translates protobuf to JSON response format |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-1-gateway/c3-113-user-handler.md
+++ b/.c3/c3-1-gateway/c3-113-user-handler.md
@@ -1,0 +1,54 @@
+---
+id: c3-113
+c3-version: 4
+title: user-handler
+type: component
+category: feature
+parent: c3-1
+goal: Expose user profile endpoints via HTTP REST
+summary: Handlers translating HTTP profile requests to User Service gRPC calls
+---
+
+# user-handler
+
+## Goal
+
+Expose user profile endpoints via HTTP REST.
+
+## Container Connection
+
+Enables profile management through the HTTP API. Without this handler, authenticated users cannot view or update their profile information. Requires authenticated user context from auth-middleware (c3-102).
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | User Service gRPC client | For get/update profile operations |
+| OUT (provides) | HTTP user profile responses | JSON profile data to API consumers |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `backend/services/gateway/internal/handler/user_handler.go` | Get/update profile handlers |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-jwt-auth-flow | Requires authenticated user context |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-2-user-service/README.md
+++ b/.c3/c3-2-user-service/README.md
@@ -1,0 +1,52 @@
+---
+id: c3-2
+c3-version: 4
+title: user-service
+type: container
+boundary: service
+parent: c3-0
+goal: Manage user identity, authentication, and profile data
+summary: gRPC service handling registration, login, JWT token lifecycle, and profile CRUD
+---
+
+# user-service
+
+## Goal
+
+Manage user identity, authentication, and profile data
+
+## Responsibilities
+
+- User registration and login with password hashing
+- JWT access and refresh token generation and rotation
+- Profile management (get/update)
+- Kafka event publishing for user lifecycle events
+
+## Complexity Assessment
+
+**Level:** moderate
+**Why:** JWT generation, password hashing, refresh token rotation
+
+## Components
+
+| ID | Name | Category | Status | Goal Contribution |
+|----|------|----------|--------|-------------------|
+| c3-201 | grpc-server | foundation | active | Implements UserService protobuf interface |
+| c3-202 | user-repository | foundation | active | Persists user data with password hashing in PostgreSQL |
+| c3-210 | auth-logic | feature | active | Handles register/login/refresh/logout business logic |
+| c3-211 | profile-management | feature | active | Handles profile get/update operations |
+
+## Layer Constraints
+
+This container operates within these boundaries:
+
+**MUST:**
+- Coordinate components within its boundary
+- Define how context linkages are fulfilled internally
+- Own its technology stack decisions
+
+**MUST NOT:**
+- Define system-wide policies (context responsibility)
+- Implement business logic directly (component responsibility)
+- Bypass refs for cross-cutting concerns
+- Orchestrate other containers (context responsibility)

--- a/.c3/c3-2-user-service/c3-201-grpc-server.md
+++ b/.c3/c3-2-user-service/c3-201-grpc-server.md
@@ -1,0 +1,55 @@
+---
+id: c3-201
+c3-version: 4
+title: grpc-server
+type: component
+category: foundation
+parent: c3-2
+goal: Implement the UserService protobuf interface
+summary: gRPC server translating protobuf requests to service layer calls
+---
+
+# grpc-server
+
+## Goal
+
+Implement the UserService protobuf interface.
+
+## Container Connection
+
+Entry point for all user service operations via gRPC. Without this server, the gateway has no way to reach user authentication or profile functionality. Listens on port 50051 and delegates to the service layer for business logic.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | User service business logic | Auth logic (c3-210) and profile management (c3-211) |
+| OUT (provides) | gRPC UserService interface | To gateway handlers (c3-110, c3-113) |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `backend/services/user/internal/grpc/server.go` | UserService gRPC implementation |
+| `backend/services/user/cmd/main.go` | Server bootstrap and dependency wiring |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-grpc-service-structure | Follows standard gRPC service layout |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-2-user-service/c3-202-user-repository.md
+++ b/.c3/c3-2-user-service/c3-202-user-repository.md
@@ -1,0 +1,55 @@
+---
+id: c3-202
+c3-version: 4
+title: user-repository
+type: component
+category: foundation
+parent: c3-2
+goal: Persist user data in PostgreSQL with secure password storage
+summary: PGX-based user CRUD with bcrypt password hashing
+---
+
+# user-repository
+
+## Goal
+
+Persist user data in PostgreSQL with secure password storage.
+
+## Container Connection
+
+Without data persistence, no users can register or authenticate. This component provides the data access layer for user records in the `ticketbox_user` database (port 5433), using bcrypt for password hashing and PGX for PostgreSQL connectivity.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | PostgreSQL connection pool | From shared database helper (c3-702) |
+| OUT (provides) | User CRUD operations | To auth logic (c3-210) and profile management (c3-211) |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `backend/services/user/internal/repository/user_repository.go` | Repository interface definition |
+| `backend/services/user/internal/repository/postgres_user_repository.go` | PGX implementation with bcrypt |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-repository-pattern | Interface + PostgreSQL implementation pattern |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-2-user-service/c3-210-auth-logic.md
+++ b/.c3/c3-2-user-service/c3-210-auth-logic.md
@@ -1,0 +1,55 @@
+---
+id: c3-210
+c3-version: 4
+title: auth-logic
+type: component
+category: feature
+parent: c3-2
+goal: Handle user authentication business logic
+summary: Register, login, JWT generation, refresh token rotation, logout
+---
+
+# auth-logic
+
+## Goal
+
+Handle user authentication business logic.
+
+## Container Connection
+
+Core authentication flows enabling secure access to the platform. Implements register, login, JWT generation, refresh token rotation, and logout. Without this logic, no user can obtain credentials to access protected resources.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | User repository | c3-202 for user persistence and credential lookup |
+| IN (uses) | Kafka producer | For publishing user registration events |
+| OUT (provides) | JWT tokens and user records | To gRPC server (c3-201) |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `backend/services/user/internal/service/user_service.go` | Auth business logic (register, login, refresh, logout) |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-jwt-auth-flow | Generates JWT access and refresh tokens |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-2-user-service/c3-211-profile-management.md
+++ b/.c3/c3-2-user-service/c3-211-profile-management.md
@@ -1,0 +1,54 @@
+---
+id: c3-211
+c3-version: 4
+title: profile-management
+type: component
+category: feature
+parent: c3-2
+goal: Handle user profile read and update operations
+summary: Profile get/update via repository layer
+---
+
+# profile-management
+
+## Goal
+
+Handle user profile read and update operations.
+
+## Container Connection
+
+Enables users to manage their profile information. Without this, authenticated users cannot view or modify their account details. Delegates data access to the user repository.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | User repository | c3-202 for user data access |
+| OUT (provides) | Profile data | To gRPC server (c3-201) |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `backend/services/user/internal/service/user_service.go` | Profile operations (shared service file with auth logic) |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-repository-pattern | Uses repository for data access |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-3-event-service/README.md
+++ b/.c3/c3-3-event-service/README.md
@@ -1,0 +1,52 @@
+---
+id: c3-3
+c3-version: 4
+title: event-service
+type: container
+boundary: service
+parent: c3-0
+goal: Manage events and enforce ticket availability with atomic updates
+summary: gRPC service providing event CRUD and row-level-locked availability decrements
+---
+
+# event-service
+
+## Goal
+
+Manage events and enforce ticket availability with atomic updates
+
+## Responsibilities
+
+- Event lifecycle CRUD operations
+- Ticket tier management
+- Atomic availability updates with SELECT FOR UPDATE row-level locking
+- Version-based optimistic locking as alternative concurrency mode
+
+## Complexity Assessment
+
+**Level:** complex
+**Why:** Row-level locking critical path, concurrent availability management, optimistic versioning
+
+## Components
+
+| ID | Name | Category | Status | Goal Contribution |
+|----|------|----------|--------|-------------------|
+| c3-301 | grpc-server | foundation | active | Implements EventService protobuf interface |
+| c3-302 | event-repository | foundation | active | Persists events/tiers with SELECT FOR UPDATE locking |
+| c3-310 | event-crud | feature | active | Manages event and tier lifecycle |
+| c3-311 | ticket-availability | feature | active | Enforces availability invariant under concurrency |
+
+## Layer Constraints
+
+This container operates within these boundaries:
+
+**MUST:**
+- Coordinate components within its boundary
+- Define how context linkages are fulfilled internally
+- Own its technology stack decisions
+
+**MUST NOT:**
+- Define system-wide policies (context responsibility)
+- Implement business logic directly (component responsibility)
+- Bypass refs for cross-cutting concerns
+- Orchestrate other containers (context responsibility)

--- a/.c3/c3-3-event-service/c3-301-grpc-server.md
+++ b/.c3/c3-3-event-service/c3-301-grpc-server.md
@@ -1,0 +1,55 @@
+---
+id: c3-301
+c3-version: 4
+title: grpc-server
+type: component
+category: foundation
+parent: c3-3
+goal: Implement the EventService protobuf interface
+summary: gRPC server translating protobuf requests to event service layer calls
+---
+
+# grpc-server
+
+## Goal
+
+Implement the EventService protobuf interface.
+
+## Container Connection
+
+Entry point for all event operations via gRPC. Without this server, the gateway cannot serve event data and the booking service cannot check ticket availability. Listens on port 50052 and delegates to the event service layer.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Event service business logic | Event CRUD (c3-310) and ticket availability (c3-311) |
+| OUT (provides) | gRPC EventService interface | To gateway handler (c3-111) and booking service (c3-410) |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `backend/services/event/internal/grpc/server.go` | EventService gRPC implementation |
+| `backend/services/event/cmd/main.go` | Server bootstrap and dependency wiring |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-grpc-service-structure | Follows standard gRPC service layout |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-3-event-service/c3-302-event-repository.md
+++ b/.c3/c3-3-event-service/c3-302-event-repository.md
@@ -1,0 +1,56 @@
+---
+id: c3-302
+c3-version: 4
+title: event-repository
+type: component
+category: foundation
+parent: c3-3
+goal: Persist event and ticket tier data with row-level locking support
+summary: PGX-based event/tier CRUD with SELECT FOR UPDATE for availability
+---
+
+# event-repository
+
+## Goal
+
+Persist event and ticket tier data with row-level locking support.
+
+## Container Connection
+
+Provides the atomic data operations that prevent double bookings. Without this repository, events cannot be stored and ticket availability cannot be atomically checked and decremented. Uses `SELECT FOR UPDATE` to serialize concurrent access to ticket tier rows in the `ticketbox_event` database (port 5434).
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | PostgreSQL connection pool | From shared database helper (c3-702) |
+| OUT (provides) | Event/tier CRUD with row-level locking | To event CRUD (c3-310) and ticket availability (c3-311) |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `backend/services/event/internal/repository/event_repository.go` | Repository interface definition |
+| `backend/services/event/internal/repository/postgres_event_repository.go` | PGX implementation with SELECT FOR UPDATE |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-repository-pattern | Interface + PostgreSQL implementation pattern |
+| ref-concurrency-control | Implements row-level locking for availability |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-3-event-service/c3-310-event-crud.md
+++ b/.c3/c3-3-event-service/c3-310-event-crud.md
@@ -1,0 +1,54 @@
+---
+id: c3-310
+c3-version: 4
+title: event-crud
+type: component
+category: feature
+parent: c3-3
+goal: Manage event and ticket tier lifecycle
+summary: Create, read, update, delete events with their associated ticket tiers
+---
+
+# event-crud
+
+## Goal
+
+Manage event and ticket tier lifecycle.
+
+## Container Connection
+
+Provides the event catalog that users browse and book from. Without event CRUD, no events exist in the system for users to discover or purchase tickets for. Manages the full lifecycle of events and their associated ticket tiers.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Event repository | c3-302 for event and tier persistence |
+| OUT (provides) | Event lifecycle operations | To gRPC server (c3-301) |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `backend/services/event/internal/service/event_service.go` | Event CRUD business logic |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-repository-pattern | Uses repository for data access |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-3-event-service/c3-311-ticket-availability.md
+++ b/.c3/c3-3-event-service/c3-311-ticket-availability.md
@@ -1,0 +1,54 @@
+---
+id: c3-311
+c3-version: 4
+title: ticket-availability
+type: component
+category: feature
+parent: c3-3
+goal: Enforce ticket availability invariant under high concurrency
+summary: Atomic availability decrements via row-level locking or optimistic versioning
+---
+
+# ticket-availability
+
+## Goal
+
+Enforce ticket availability invariant under high concurrency.
+
+## Container Connection
+
+THE critical component -- without it, double bookings occur. When 100K+ users attempt simultaneous purchases, this component ensures `available_quantity` is never decremented below zero. Uses `SELECT FOR UPDATE` on ticket tier rows to serialize concurrent attempts, with an optional optimistic mode via the `version` column.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Event repository with locking | c3-302 for `SELECT FOR UPDATE` on ticket_tiers |
+| OUT (provides) | Availability check/decrement result | To gRPC server (c3-301), consumed by booking service (c3-410) |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `backend/services/event/internal/service/event_service.go` | UpdateTicketAvailability logic |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-concurrency-control | Implements the core locking strategy (pessimistic and optimistic) |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-4-booking-service/README.md
+++ b/.c3/c3-4-booking-service/README.md
@@ -1,0 +1,52 @@
+---
+id: c3-4
+c3-version: 4
+title: booking-service
+type: container
+boundary: service
+parent: c3-0
+goal: Create and manage bookings transactionally with concurrency control
+summary: gRPC service orchestrating cross-service booking transactions with outbox pattern
+---
+
+# booking-service
+
+## Goal
+
+Create and manage bookings transactionally with concurrency control
+
+## Responsibilities
+
+- Transactional booking creation with atomicity guarantees
+- Cross-service availability checks via event service gRPC calls
+- Outbox-based event publishing to Kafka for downstream consumers
+- Booking lifecycle management (get/list/cancel)
+
+## Complexity Assessment
+
+**Level:** complex
+**Why:** Cross-service transaction coordination, outbox pattern, configurable locking modes
+
+## Components
+
+| ID | Name | Category | Status | Goal Contribution |
+|----|------|----------|--------|-------------------|
+| c3-401 | grpc-server | foundation | active | Implements BookingService protobuf interface |
+| c3-402 | booking-repository | foundation | active | Persists bookings and outbox entries in PostgreSQL |
+| c3-410 | booking-creation | feature | active | Orchestrates booking creation with event-service availability check |
+| c3-411 | booking-management | feature | active | Handles get/list/cancel booking operations |
+
+## Layer Constraints
+
+This container operates within these boundaries:
+
+**MUST:**
+- Coordinate components within its boundary
+- Define how context linkages are fulfilled internally
+- Own its technology stack decisions
+
+**MUST NOT:**
+- Define system-wide policies (context responsibility)
+- Implement business logic directly (component responsibility)
+- Bypass refs for cross-cutting concerns
+- Orchestrate other containers (context responsibility)

--- a/.c3/c3-4-booking-service/c3-401-grpc-server.md
+++ b/.c3/c3-4-booking-service/c3-401-grpc-server.md
@@ -1,0 +1,55 @@
+---
+id: c3-401
+c3-version: 4
+title: grpc-server
+type: component
+category: foundation
+parent: c3-4
+goal: Implement the BookingService protobuf interface
+summary: gRPC server translating protobuf requests to booking service layer calls
+---
+
+# grpc-server
+
+## Goal
+
+Implement the BookingService protobuf interface.
+
+## Container Connection
+
+Entry point for all booking operations via gRPC. Without this server, the gateway cannot create or manage bookings. Listens on port 50053 and delegates to the booking service layer. Supports configurable `BOOKING_MODE` (pessimistic or optimistic).
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Booking service business logic | Booking creation (c3-410) and management (c3-411) |
+| OUT (provides) | gRPC BookingService interface | To gateway handler (c3-112) |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `backend/services/booking/internal/grpc/server.go` | BookingService gRPC implementation |
+| `backend/services/booking/cmd/main.go` | Server bootstrap and dependency wiring |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-grpc-service-structure | Follows standard gRPC service layout |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-4-booking-service/c3-402-booking-repository.md
+++ b/.c3/c3-4-booking-service/c3-402-booking-repository.md
@@ -1,0 +1,56 @@
+---
+id: c3-402
+c3-version: 4
+title: booking-repository
+type: component
+category: foundation
+parent: c3-4
+goal: Persist booking data and outbox entries in PostgreSQL
+summary: PGX-based booking CRUD with transactional outbox writes
+---
+
+# booking-repository
+
+## Goal
+
+Persist booking data and outbox entries in PostgreSQL.
+
+## Container Connection
+
+Stores booking records and ensures reliable event publishing via the outbox pattern. Without this repository, bookings cannot be persisted and downstream notification events would be lost. Writes booking and outbox records within the same database transaction in the `ticketbox_booking` database (port 5435).
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | PostgreSQL connection pool | From shared database helper (c3-702) |
+| OUT (provides) | Booking CRUD + outbox operations | To booking creation (c3-410) and management (c3-411) |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `backend/services/booking/internal/repository/booking_repository.go` | Repository interface definition |
+| `backend/services/booking/internal/repository/postgres_booking_repository.go` | PGX implementation with transactional outbox |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-repository-pattern | Interface + PostgreSQL implementation pattern |
+| ref-outbox-pattern | Transactional outbox writes alongside booking records |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-4-booking-service/c3-410-booking-creation.md
+++ b/.c3/c3-4-booking-service/c3-410-booking-creation.md
@@ -1,0 +1,56 @@
+---
+id: c3-410
+c3-version: 4
+title: booking-creation
+type: component
+category: feature
+parent: c3-4
+goal: Orchestrate transactional booking creation with cross-service availability check
+summary: Creates booking by calling event-service for availability then persisting with outbox
+---
+
+# booking-creation
+
+## Goal
+
+Orchestrate transactional booking creation with cross-service availability check.
+
+## Container Connection
+
+The core booking flow -- coordinates availability check and booking persistence. Calls the Event Service gRPC client to atomically decrement ticket availability, then persists the booking record alongside an outbox event in a single transaction. Supports configurable pessimistic/optimistic concurrency mode via `BOOKING_MODE`.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Event Service gRPC client | For UpdateTicketAvailability (c3-311) |
+| IN (uses) | Booking repository | c3-402 for transactional booking + outbox persistence |
+| OUT (provides) | Created booking with outbox event | To gRPC server (c3-401) |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `backend/services/booking/internal/service/booking_service.go` | CreateBooking orchestration |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-concurrency-control | Configurable pessimistic/optimistic booking mode |
+| ref-outbox-pattern | Publishes booking events via transactional outbox |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-4-booking-service/c3-411-booking-management.md
+++ b/.c3/c3-4-booking-service/c3-411-booking-management.md
@@ -1,0 +1,54 @@
+---
+id: c3-411
+c3-version: 4
+title: booking-management
+type: component
+category: feature
+parent: c3-4
+goal: Handle booking queries and cancellation
+summary: Get, list, and cancel bookings via repository
+---
+
+# booking-management
+
+## Goal
+
+Handle booking queries and cancellation.
+
+## Container Connection
+
+Enables users to view and manage their booking history. Without this, users have no way to check booking status or cancel unwanted reservations. Provides get-by-ID, list-by-user, and cancel operations through the repository layer.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Booking repository | c3-402 for booking data access |
+| OUT (provides) | Booking query/cancel results | To gRPC server (c3-401) |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `backend/services/booking/internal/service/booking_service.go` | Get/list/cancel logic (shared service file with creation) |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-repository-pattern | Uses repository for data access |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-5-notification-service/README.md
+++ b/.c3/c3-5-notification-service/README.md
@@ -1,0 +1,50 @@
+---
+id: c3-5
+c3-version: 4
+title: notification-service
+type: container
+boundary: worker
+parent: c3-0
+goal: Consume booking events asynchronously and persist notifications
+summary: Kafka consumer processing booking events into stored notifications
+---
+
+# notification-service
+
+## Goal
+
+Consume booking events asynchronously and persist notifications
+
+## Responsibilities
+
+- Kafka topic consumption for booking lifecycle events
+- Notification persistence in dedicated PostgreSQL database
+- Event deserialization and validation
+
+## Complexity Assessment
+
+**Level:** simple
+**Why:** Straightforward consume-and-store pattern
+
+## Components
+
+| ID | Name | Category | Status | Goal Contribution |
+|----|------|----------|--------|-------------------|
+| c3-501 | kafka-consumer | foundation | active | Subscribes to Kafka booking topics |
+| c3-502 | notification-repository | foundation | active | Persists notification records in PostgreSQL |
+| c3-510 | notification-processing | feature | active | Transforms booking events into notification records |
+
+## Layer Constraints
+
+This container operates within these boundaries:
+
+**MUST:**
+- Coordinate components within its boundary
+- Define how context linkages are fulfilled internally
+- Own its technology stack decisions
+
+**MUST NOT:**
+- Define system-wide policies (context responsibility)
+- Implement business logic directly (component responsibility)
+- Bypass refs for cross-cutting concerns
+- Orchestrate other containers (context responsibility)

--- a/.c3/c3-5-notification-service/c3-501-kafka-consumer.md
+++ b/.c3/c3-5-notification-service/c3-501-kafka-consumer.md
@@ -1,0 +1,56 @@
+---
+id: c3-501
+c3-version: 4
+title: kafka-consumer
+type: component
+category: foundation
+parent: c3-5
+goal: Subscribe to Kafka booking event topics
+summary: Kafka consumer group setup for booking events
+---
+
+# kafka-consumer
+
+## Goal
+
+Subscribe to Kafka booking event topics.
+
+## Container Connection
+
+Without the consumer, no booking events are received for notification processing. This component establishes the Kafka consumer group connection and receives raw booking event messages published via the outbox pattern from the booking service.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Kafka broker | Message source for booking events |
+| IN (uses) | Shared kafka-pkg | c3-703 for consumer setup utilities |
+| OUT (provides) | Raw booking event messages | To notification processing (c3-510) |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `backend/services/notification/internal/kafka/consumer.go` | Kafka consumer setup |
+| `backend/services/notification/cmd/main.go` | Consumer bootstrap |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-outbox-pattern | Consumes events published via the outbox pattern |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-5-notification-service/c3-502-notification-repository.md
+++ b/.c3/c3-5-notification-service/c3-502-notification-repository.md
@@ -1,0 +1,55 @@
+---
+id: c3-502
+c3-version: 4
+title: notification-repository
+type: component
+category: foundation
+parent: c3-5
+goal: Persist notification records in PostgreSQL
+summary: PGX-based notification storage
+---
+
+# notification-repository
+
+## Goal
+
+Persist notification records in PostgreSQL.
+
+## Container Connection
+
+Without persistence, notifications are lost after processing. This component stores notification records in the `ticketbox_notification` database (port 5436), providing a durable record of all notifications generated from booking events.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | PostgreSQL connection pool | From shared database helper (c3-702) |
+| OUT (provides) | Notification CRUD operations | To notification processing (c3-510) |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `backend/services/notification/internal/repository/notification_repository.go` | Repository interface definition |
+| `backend/services/notification/internal/repository/postgres_notification_repository.go` | PGX implementation |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-repository-pattern | Interface + PostgreSQL implementation pattern |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-5-notification-service/c3-510-notification-processing.md
+++ b/.c3/c3-5-notification-service/c3-510-notification-processing.md
@@ -1,0 +1,55 @@
+---
+id: c3-510
+c3-version: 4
+title: notification-processing
+type: component
+category: feature
+parent: c3-5
+goal: Transform Kafka booking events into stored notification records
+summary: Deserializes booking events and persists as notifications
+---
+
+# notification-processing
+
+## Goal
+
+Transform Kafka booking events into stored notification records.
+
+## Container Connection
+
+The core processing logic that creates notifications from booking events. Without this, consumed Kafka messages are never turned into actionable notification records. Deserializes incoming booking event payloads and persists them via the notification repository.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Kafka consumer | c3-501 for raw booking event messages |
+| IN (uses) | Notification repository | c3-502 for notification persistence |
+| OUT (provides) | Stored notifications | Durable notification records in PostgreSQL |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `backend/services/notification/internal/service/notification_service.go` | Event processing and notification creation logic |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-outbox-pattern | Processes events published via the outbox pattern |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-6-frontend/README.md
+++ b/.c3/c3-6-frontend/README.md
@@ -1,0 +1,57 @@
+---
+id: c3-6
+c3-version: 4
+title: frontend
+type: container
+boundary: app
+parent: c3-0
+goal: Provide the user-facing ticket booking experience with offline development support
+summary: Next.js 16 App Router with auth/booking contexts, API proxy, and mock data fallback
+---
+
+# frontend
+
+## Goal
+
+Provide the user-facing ticket booking experience with offline development support
+
+## Responsibilities
+
+- Event browsing and search interface
+- Seat selection and booking flow with interactive venue maps
+- Auth state management (login/register/logout with session persistence)
+- API type transformation (snake_case/cents to camelCase/dollars)
+
+## Complexity Assessment
+
+**Level:** moderate
+**Why:** Multiple state contexts, SVG venue generation, type transformation layer
+
+## Components
+
+| ID | Name | Category | Status | Goal Contribution |
+|----|------|----------|--------|-------------------|
+| c3-601 | api-client | foundation | active | Singleton HTTP client with JWT auto-refresh on 401 |
+| c3-602 | auth-state | foundation | active | AuthProvider context for login/register/logout state |
+| c3-603 | booking-state | foundation | active | BookingProvider context for events, cart, and purchase flow |
+| c3-604 | data-transformers | foundation | active | Converts API snake_case/cents to frontend camelCase/dollars |
+| c3-610 | event-browsing | feature | active | Home page event listing with search and filtering |
+| c3-611 | event-detail | feature | active | Event detail page with interactive SVG venue map |
+| c3-612 | checkout | feature | active | Cart and payment checkout flow |
+| c3-613 | my-tickets | feature | active | Purchased ticket history display |
+| c3-614 | auth-pages | feature | active | Login and registration form pages |
+
+## Layer Constraints
+
+This container operates within these boundaries:
+
+**MUST:**
+- Coordinate components within its boundary
+- Define how context linkages are fulfilled internally
+- Own its technology stack decisions
+
+**MUST NOT:**
+- Define system-wide policies (context responsibility)
+- Implement business logic directly (component responsibility)
+- Bypass refs for cross-cutting concerns
+- Orchestrate other containers (context responsibility)

--- a/.c3/c3-6-frontend/c3-601-api-client.md
+++ b/.c3/c3-6-frontend/c3-601-api-client.md
@@ -1,0 +1,56 @@
+---
+id: c3-601
+c3-version: 4
+title: api-client
+type: component
+category: foundation
+parent: c3-6
+goal: Provide HTTP client with automatic JWT token management
+summary: Singleton apiClient with auto-refresh on 401, proxied via Next.js rewrites
+---
+
+# api-client
+
+## Goal
+
+Provide HTTP client with automatic JWT token management.
+
+## Container Connection
+
+All backend communication flows through this client. Without it, no frontend component can reach the gateway API. Manages access and refresh tokens in localStorage, automatically refreshes on 401 responses, and routes requests through Next.js rewrites that proxy `/api/*` to the gateway on port 8000.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | localStorage | For JWT access and refresh token persistence |
+| IN (uses) | Next.js rewrites | Proxy configuration in `next.config.ts` |
+| OUT (provides) | Typed API methods | To auth-state (c3-602), booking-state (c3-603), and all page components |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `frontend/lib/api/client.ts` | Singleton HTTP client with token refresh logic |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-jwt-auth-flow | Manages access/refresh tokens client-side |
+| ref-data-shape-mapping | Returns raw API types (snake_case, cents) before transformation |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-6-frontend/c3-602-auth-state.md
+++ b/.c3/c3-6-frontend/c3-602-auth-state.md
@@ -1,0 +1,54 @@
+---
+id: c3-602
+c3-version: 4
+title: auth-state
+type: component
+category: foundation
+parent: c3-6
+goal: Manage global authentication state across the application
+summary: AuthProvider React context with login/register/logout and session restore
+---
+
+# auth-state
+
+## Goal
+
+Manage global authentication state across the application.
+
+## Container Connection
+
+Without auth state, no component can determine the logged-in user. Provides the AuthProvider React context that wraps the entire app, exposing the `useAuth()` hook with user state, login, register, logout, and automatic session restore from localStorage on mount.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | API client | c3-601 for auth API calls (login, register, refresh, logout) |
+| OUT (provides) | useAuth() hook | User state, login, register, logout to all components |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `frontend/lib/auth-context.tsx` | AuthProvider and useAuth hook |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-jwt-auth-flow | Orchestrates the client-side auth lifecycle |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-6-frontend/c3-603-booking-state.md
+++ b/.c3/c3-6-frontend/c3-603-booking-state.md
@@ -1,0 +1,56 @@
+---
+id: c3-603
+c3-version: 4
+title: booking-state
+type: component
+category: foundation
+parent: c3-6
+goal: Manage global event listing, cart, and purchase state
+summary: BookingProvider React context with events, cart, purchase flow, and mock data fallback
+---
+
+# booking-state
+
+## Goal
+
+Manage global event listing, cart, and purchase state.
+
+## Container Connection
+
+Central state for the booking flow -- events, cart selection, and purchase. Without this, no page can access the event catalog or manage cart items. Provides the BookingProvider React context with `useBooking()` hook, fetching events from the API and falling back to mock data when the backend is unavailable.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | API client | c3-601 for event and booking API calls |
+| IN (uses) | Data transformers | c3-604 for converting API responses to frontend types |
+| IN (uses) | Mock data | `frontend/lib/mock-data.ts` for offline fallback |
+| OUT (provides) | useBooking() hook | Events, cart, purchase flow to all page components |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `frontend/lib/booking-context.tsx` | BookingProvider and useBooking hook |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-mock-data-fallback | Falls back to mock data when backend is unavailable |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-6-frontend/c3-604-data-transformers.md
+++ b/.c3/c3-6-frontend/c3-604-data-transformers.md
@@ -1,0 +1,55 @@
+---
+id: c3-604
+c3-version: 4
+title: data-transformers
+type: component
+category: foundation
+parent: c3-6
+goal: Convert API response types to frontend display types
+summary: Transforms snake_case/cents to camelCase/dollars, formats dates
+---
+
+# data-transformers
+
+## Goal
+
+Convert API response types to frontend display types.
+
+## Container Connection
+
+Without transformers, the frontend would display raw API format (price_cents, snake_case field names, RFC3339 timestamps). This component bridges the data shape gap between the Go backend JSON responses and the React frontend expectations, converting cents to dollars, renaming fields (e.g., `image_url` to `image`, `available_quantity` to `available`), and formatting dates.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Raw API types | From api-client (c3-601) responses |
+| OUT (provides) | Frontend-ready types | Dollars, formatted dates, camelCase to booking-state (c3-603) |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `frontend/lib/api/transformers.ts` | transformEvent, transformBookingToTicket functions |
+| `frontend/lib/api/types.ts` | Raw API type definitions matching backend JSON |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-data-shape-mapping | Implements the API-to-Frontend type conversion |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-6-frontend/c3-610-event-browsing.md
+++ b/.c3/c3-6-frontend/c3-610-event-browsing.md
@@ -1,0 +1,53 @@
+---
+id: c3-610
+c3-version: 4
+title: event-browsing
+type: component
+category: feature
+parent: c3-6
+goal: Display event listings with search and filtering
+summary: Home page with hero section and event card grid
+---
+
+# event-browsing
+
+## Goal
+
+Display event listings with search and filtering.
+
+## Container Connection
+
+The entry point for users to discover available events. Without this, users have no way to see what events are available for booking. Renders the home page with a hero section and a grid of event cards sourced from the booking state context.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Booking state | c3-603 for event listing data via useBooking() |
+| OUT (provides) | Event listing UI | Home page rendering for end users |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `frontend/app/page.tsx` | Home page with event listing |
+| `frontend/components/event-card.tsx` | Event card component |
+
+## Related Refs
+
+*None*
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-6-frontend/c3-611-event-detail.md
+++ b/.c3/c3-6-frontend/c3-611-event-detail.md
@@ -1,0 +1,56 @@
+---
+id: c3-611
+c3-version: 4
+title: event-detail
+type: component
+category: feature
+parent: c3-6
+goal: Show event details with interactive seat selection
+summary: Event detail page with SVG venue map for seat picking
+---
+
+# event-detail
+
+## Goal
+
+Show event details with interactive seat selection.
+
+## Container Connection
+
+Where users select specific seats before checkout. Without this, users cannot see event details or choose seats. Renders event information, an interactive SVG venue map generated from ticket tier data, and provides seat selection that feeds into the cart.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Booking state | c3-603 for event data and cart management via useBooking() |
+| IN (uses) | Venue layout generator | `frontend/lib/api/generate-venue-layout.ts` for SVG generation |
+| OUT (provides) | Selected seats to cart | Seat selections added to booking state |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `frontend/app/events/[id]/page.tsx` | Event detail view |
+| `frontend/app/events/[id]/seats/page.tsx` | Seat selection page |
+| `frontend/components/venue-map.tsx` | Interactive SVG venue component |
+| `frontend/lib/api/generate-venue-layout.ts` | SVG venue generation from tier data |
+
+## Related Refs
+
+*None*
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-6-frontend/c3-612-checkout.md
+++ b/.c3/c3-6-frontend/c3-612-checkout.md
@@ -1,0 +1,52 @@
+---
+id: c3-612
+c3-version: 4
+title: checkout
+type: component
+category: feature
+parent: c3-6
+goal: Handle cart review and booking purchase
+summary: Checkout page with cart summary and purchase confirmation
+---
+
+# checkout
+
+## Goal
+
+Handle cart review and booking purchase.
+
+## Container Connection
+
+Converts selected seats into a confirmed booking. Without this, users can select seats but never complete a purchase. Displays the cart summary with pricing and triggers the purchase flow through the booking state context, which calls the backend booking API.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Booking state | c3-603 for cart data and purchase flow via useBooking() |
+| OUT (provides) | Booking confirmation | Purchase result displayed to user |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `frontend/app/checkout/page.tsx` | Checkout page with cart summary and purchase |
+
+## Related Refs
+
+*None*
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-6-frontend/c3-613-my-tickets.md
+++ b/.c3/c3-6-frontend/c3-613-my-tickets.md
@@ -1,0 +1,52 @@
+---
+id: c3-613
+c3-version: 4
+title: my-tickets
+type: component
+category: feature
+parent: c3-6
+goal: Display user's purchased ticket history
+summary: Ticket listing page showing booking status and details
+---
+
+# my-tickets
+
+## Goal
+
+Display user's purchased ticket history.
+
+## Container Connection
+
+Enables users to review their past and upcoming bookings. Without this, users have no way to see their purchase history or check booking status. Retrieves purchased tickets from the booking state context and renders them with status and event details.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Booking state | c3-603 for purchased tickets via useBooking() |
+| OUT (provides) | Ticket history UI | Purchased ticket listing for end users |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `frontend/app/my-tickets/page.tsx` | My tickets page |
+
+## Related Refs
+
+*None*
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-6-frontend/c3-614-auth-pages.md
+++ b/.c3/c3-6-frontend/c3-614-auth-pages.md
@@ -1,0 +1,55 @@
+---
+id: c3-614
+c3-version: 4
+title: auth-pages
+type: component
+category: feature
+parent: c3-6
+goal: Provide login and registration form interfaces
+summary: Login and register pages with form validation
+---
+
+# auth-pages
+
+## Goal
+
+Provide login and registration form interfaces.
+
+## Container Connection
+
+Entry point for new and returning users to authenticate. Without these pages, users cannot create accounts or sign in. Renders login and registration forms with client-side validation, delegating auth operations to the auth state context.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Auth state | c3-602 for login/register functions via useAuth() |
+| OUT (provides) | Authenticated session | Triggers auth state update on successful login/register |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `frontend/app/login/page.tsx` | Login form page |
+| `frontend/app/register/page.tsx` | Registration form page |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-jwt-auth-flow | Uses auth context for token-based authentication |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-7-shared-backend/README.md
+++ b/.c3/c3-7-shared-backend/README.md
@@ -1,0 +1,53 @@
+---
+id: c3-7
+c3-version: 4
+title: shared-backend
+type: container
+boundary: library
+parent: c3-0
+goal: Provide common infrastructure enabling consistent behavior across all backend services
+summary: Go packages for config, database, Kafka, gRPC middleware, and generated protobuf code
+---
+
+# shared-backend
+
+## Goal
+
+Provide common infrastructure enabling consistent behavior across all backend services
+
+## Responsibilities
+
+- Environment-based configuration loading for all services
+- PostgreSQL connection pooling and management
+- Kafka producer/consumer setup utilities
+- gRPC logging middleware for observability
+
+## Complexity Assessment
+
+**Level:** simple
+**Why:** Utility packages with minimal business logic
+
+## Components
+
+| ID | Name | Category | Status | Goal Contribution |
+|----|------|----------|--------|-------------------|
+| c3-701 | config | foundation | active | Viper-based environment config loading |
+| c3-702 | database | foundation | active | PGX connection pool creation and management |
+| c3-703 | kafka-pkg | foundation | active | Kafka producer and consumer setup utilities |
+| c3-704 | grpc-middleware | foundation | active | gRPC unary logging interceptor |
+| c3-705 | proto-generated | foundation | active | Generated protobuf Go code for all service contracts |
+
+## Layer Constraints
+
+This container operates within these boundaries:
+
+**MUST:**
+- Coordinate components within its boundary
+- Define how context linkages are fulfilled internally
+- Own its technology stack decisions
+
+**MUST NOT:**
+- Define system-wide policies (context responsibility)
+- Implement business logic directly (component responsibility)
+- Bypass refs for cross-cutting concerns
+- Orchestrate other containers (context responsibility)

--- a/.c3/c3-7-shared-backend/c3-701-config.md
+++ b/.c3/c3-7-shared-backend/c3-701-config.md
@@ -1,0 +1,52 @@
+---
+id: c3-701
+c3-version: 4
+title: config
+type: component
+category: foundation
+parent: c3-7
+goal: Provide environment-based configuration loading for all services
+summary: Viper config loading SERVICE_NAME, ports, DATABASE_URL, JWT_SECRET
+---
+
+# config
+
+## Goal
+
+Provide environment-based configuration loading for all services.
+
+## Container Connection
+
+Every service needs configuration -- this provides the common loader. Without it, services cannot read DATABASE_URL, JWT_SECRET, service ports, or BOOKING_MODE from the environment. Uses Viper for environment variable binding and returns a typed config struct.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Environment variables | SERVICE_NAME, DATABASE_URL, JWT_SECRET, ports, KAFKA_BROKERS |
+| OUT (provides) | Typed config struct | To all service bootstrap code (cmd/main.go files) |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `backend/pkg/config/config.go` | Viper-based config loading |
+
+## Related Refs
+
+*None*
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-7-shared-backend/c3-702-database.md
+++ b/.c3/c3-7-shared-backend/c3-702-database.md
@@ -1,0 +1,52 @@
+---
+id: c3-702
+c3-version: 4
+title: database
+type: component
+category: foundation
+parent: c3-7
+goal: Provide PostgreSQL connection pool creation for all services
+summary: PGX pool helper with connection string parsing
+---
+
+# database
+
+## Goal
+
+Provide PostgreSQL connection pool creation for all services.
+
+## Container Connection
+
+All services with databases use this to create their connection pool. Without it, no service can connect to its PostgreSQL instance. Parses DATABASE_URL and returns a configured `*pgxpool.Pool` used by all repository implementations across user (port 5433), event (port 5434), booking (port 5435), and notification (port 5436) databases.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | DATABASE_URL | From config (c3-701) |
+| OUT (provides) | *pgxpool.Pool | To all repository components (c3-202, c3-302, c3-402, c3-502) |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `backend/pkg/database/postgres.go` | PGX pool creation helper |
+
+## Related Refs
+
+*None*
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-7-shared-backend/c3-703-kafka-pkg.md
+++ b/.c3/c3-7-shared-backend/c3-703-kafka-pkg.md
@@ -1,0 +1,55 @@
+---
+id: c3-703
+c3-version: 4
+title: kafka-pkg
+type: component
+category: foundation
+parent: c3-7
+goal: Provide Kafka producer and consumer utilities for all services
+summary: Shared Kafka setup for event publishing and consumption
+---
+
+# kafka-pkg
+
+## Goal
+
+Provide Kafka producer and consumer utilities for all services.
+
+## Container Connection
+
+Services use this for reliable async event communication. Without it, the booking service cannot publish outbox events and the notification service cannot consume them. Provides reusable producer and consumer setup that standardizes Kafka connectivity across the platform.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Kafka broker address | From config (c3-701) KAFKA_BROKERS |
+| OUT (provides) | Producer and consumer instances | Producer to booking service (c3-410), consumer to notification service (c3-501) |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `backend/pkg/kafka/producer.go` | Kafka event producer |
+| `backend/pkg/kafka/consumer.go` | Kafka event consumer |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-outbox-pattern | Producer used for outbox event publishing |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-7-shared-backend/c3-704-grpc-middleware.md
+++ b/.c3/c3-7-shared-backend/c3-704-grpc-middleware.md
@@ -1,0 +1,54 @@
+---
+id: c3-704
+c3-version: 4
+title: grpc-middleware
+type: component
+category: foundation
+parent: c3-7
+goal: Provide gRPC logging interceptor for all services
+summary: Unary interceptor with structured zap logging
+---
+
+# grpc-middleware
+
+## Goal
+
+Provide gRPC logging interceptor for all services.
+
+## Container Connection
+
+Consistent request logging across all gRPC services. Without this, gRPC calls across user, event, and booking services would lack structured observability. Implements a unary server interceptor that logs method, duration, and error status using zap structured logging.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | zap logger | Structured logging library |
+| OUT (provides) | gRPC UnaryServerInterceptor | To all gRPC server bootstraps (c3-201, c3-301, c3-401) |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `backend/pkg/middleware/logging.go` | gRPC logging interceptor |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-grpc-service-structure | Part of the standard gRPC service setup |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/c3-7-shared-backend/c3-705-proto-generated.md
+++ b/.c3/c3-7-shared-backend/c3-705-proto-generated.md
@@ -1,0 +1,56 @@
+---
+id: c3-705
+c3-version: 4
+title: proto-generated
+type: component
+category: foundation
+parent: c3-7
+goal: Provide generated protobuf Go code for all service contracts
+summary: Generated from proto/ definitions, used by all services for gRPC communication
+---
+
+# proto-generated
+
+## Goal
+
+Provide generated protobuf Go code for all service contracts.
+
+## Container Connection
+
+Type-safe service contracts enabling gRPC communication. Without generated stubs, no service can implement or call gRPC interfaces. Generated from proto definitions at `backend/proto/{user,event,booking}/v1/*.proto` via `make proto`, producing Go stubs that all services import for request/response types and client/server interfaces.
+
+## Dependencies
+
+| Direction | What | From/To |
+|-----------|------|---------|
+| IN (uses) | Proto definitions | `backend/proto/` source .proto files |
+| OUT (provides) | Go stubs for user/event/booking services | To all gRPC servers and clients across the platform |
+
+## Code References
+
+| File | Purpose |
+|------|---------|
+| `backend/pkg/proto/user/v1/user.pb.go` | User service generated stubs |
+| `backend/pkg/proto/event/v1/event.pb.go` | Event service generated stubs |
+| `backend/pkg/proto/booking/v1/booking.pb.go` | Booking service generated stubs |
+
+## Related Refs
+
+| Ref | How It Serves Goal |
+|-----|-------------------|
+| ref-grpc-service-structure | Generated code follows the protobuf contract pattern |
+
+## Layer Constraints
+
+This component operates within these boundaries:
+
+**MUST:**
+- Focus on single responsibility within its domain
+- Cite refs for patterns instead of re-implementing
+- Hand off cross-component concerns to container
+
+**MUST NOT:**
+- Import directly from other containers (use container linkages)
+- Define system-wide configuration (context responsibility)
+- Orchestrate multiple peer components (container responsibility)
+- Redefine patterns that exist in refs

--- a/.c3/code-map.yaml
+++ b/.c3/code-map.yaml
@@ -1,0 +1,148 @@
+# C3 code-map: maps component and ref IDs to source file glob patterns.
+# Edit patterns, then verify with: c3x coverage
+
+# Components — Gateway (c3-1)
+c3-101:
+  - backend/services/gateway/internal/router/**
+  - backend/services/gateway/cmd/**
+c3-102:
+  - backend/services/gateway/internal/middleware/**
+c3-110:
+  - backend/services/gateway/internal/handler/auth_handler.go
+c3-111:
+  - backend/services/gateway/internal/handler/event_handler.go
+c3-112:
+  - backend/services/gateway/internal/handler/booking_handler.go
+c3-113:
+  - backend/services/gateway/internal/handler/user_handler.go
+
+# Components — User Service (c3-2)
+c3-201:
+  - backend/services/user/internal/grpc/**
+  - backend/services/user/cmd/**
+c3-202:
+  - backend/services/user/internal/repository/**
+c3-210:
+  - backend/services/user/internal/service/**
+c3-211:
+  - backend/services/user/internal/service/**
+
+# Components — Event Service (c3-3)
+c3-301:
+  - backend/services/event/internal/grpc/**
+  - backend/services/event/cmd/**
+c3-302:
+  - backend/services/event/internal/repository/**
+c3-310:
+  - backend/services/event/internal/service/**
+c3-311:
+  - backend/services/event/internal/service/**
+
+# Components — Booking Service (c3-4)
+c3-401:
+  - backend/services/booking/internal/grpc/**
+  - backend/services/booking/cmd/**
+c3-402:
+  - backend/services/booking/internal/repository/**
+c3-410:
+  - backend/services/booking/internal/service/**
+c3-411:
+  - backend/services/booking/internal/service/**
+
+# Components — Notification Service (c3-5)
+c3-501:
+  - backend/services/notification/internal/kafka/**
+  - backend/services/notification/cmd/**
+c3-502:
+  - backend/services/notification/internal/repository/**
+c3-510:
+  - backend/services/notification/internal/service/**
+
+# Components — Frontend (c3-6)
+c3-601:
+  - frontend/lib/api/client.ts
+c3-602:
+  - frontend/lib/auth-context.tsx
+c3-603:
+  - frontend/lib/booking-context.tsx
+c3-604:
+  - frontend/lib/api/transformers.ts
+  - frontend/lib/api/types.ts
+c3-610:
+  - frontend/app/page.tsx
+  - frontend/components/event-card.tsx
+c3-611:
+  - frontend/app/events/**
+  - frontend/components/venue-map.tsx
+  - frontend/components/seat-legend.tsx
+  - frontend/components/seat-tooltip.tsx
+  - frontend/components/section-picker.tsx
+  - frontend/lib/api/generate-venue-layout.ts
+c3-612:
+  - frontend/app/checkout/**
+c3-613:
+  - frontend/app/my-tickets/**
+c3-614:
+  - frontend/app/login/**
+  - frontend/app/register/**
+
+# Components — Shared Backend (c3-7)
+c3-701:
+  - backend/pkg/config/**
+c3-702:
+  - backend/pkg/database/**
+c3-703:
+  - backend/pkg/kafka/**
+c3-704:
+  - backend/pkg/middleware/**
+c3-705:
+  - backend/pkg/proto/**
+
+# Refs
+ref-concurrency-control: []
+ref-data-shape-mapping: []
+ref-grpc-service-structure: []
+ref-jwt-auth-flow: []
+ref-mock-data-fallback: []
+ref-outbox-pattern: []
+ref-repository-pattern: []
+
+# Exclusions (not counted in coverage)
+_exclude:
+  - "**/*_test.go"
+  - "**/go.sum"
+  - "**/node_modules/**"
+  - "**/.next/**"
+  - "**/migrations/**"
+  - "**/Dockerfile"
+  - "**/Makefile"
+  - "**/*.proto"
+  - backend/docker-compose.yml
+  - backend/go.work
+  - backend/go.work.sum
+  - backend/scripts/**
+  - frontend/public/**
+  - frontend/package-lock.json
+  - frontend/tsconfig.json
+  - frontend/next.config.ts
+  - frontend/postcss.config.mjs
+  - frontend/tailwind.config.ts
+  - frontend/.env*
+  - frontend/next-env.d.ts
+  - frontend/app/layout.tsx
+  - frontend/app/globals.css
+  - frontend/components/navbar.tsx
+  - frontend/lib/types.ts
+  - frontend/lib/mock-data.ts
+  - design/**
+  - docs/**
+  - "**/*.md"
+  - "**/go.mod"
+  - "**/.gitignore"
+  - "**/bin/**"
+  - backend/services/*/internal/domain/**
+  - backend/services/*/internal/kafka/producer.go
+  - backend/.env*
+  - frontend/eslint.config.mjs
+  - frontend/package.json
+  - frontend/app/favicon.ico

--- a/.c3/config.yaml
+++ b/.c3/config.yaml
@@ -1,0 +1,1 @@
+# C3 configuration

--- a/.c3/refs/ref-concurrency-control.md
+++ b/.c3/refs/ref-concurrency-control.md
@@ -1,0 +1,58 @@
+---
+id: ref-concurrency-control
+c3-version: 4
+title: concurrency-control
+goal: Prevent double bookings under 100K+ concurrent users
+scope: [c3-3, c3-4]
+---
+
+# concurrency-control
+
+## Goal
+
+Prevent double bookings under 100K+ concurrent users.
+
+## Choice
+
+Two modes configurable via `BOOKING_MODE` env var. **Pessimistic (default):** Event Service uses `SELECT ... FOR UPDATE` row-level lock on ticket_tiers, serializing concurrent availability checks. **Optimistic:** Uses `version` column, failing on version mismatch.
+
+## Why
+
+Pessimistic locking is simpler and guarantees correctness under high contention. Optimistic mode available for lower-contention scenarios where throughput matters more. Both prevent the invariant violation: `available_quantity` must never go negative.
+
+## How
+
+| Guideline | Example |
+|-----------|---------|
+| Pessimistic: SELECT FOR UPDATE | `SELECT ... FROM ticket_tiers WHERE id = $1 FOR UPDATE` |
+| Check before decrement | `IF available_quantity >= requested THEN decrement` |
+| Optimistic: version check | `UPDATE ... SET version = version + 1 WHERE version = $expected` |
+| BOOKING_MODE env var | `pessimistic` (default) or `optimistic` |
+| Booking Service calls Event Service | gRPC `UpdateTicketAvailability` for atomic check-and-decrement |
+
+## Not This
+
+| Alternative | Rejected Because |
+|-------------|------------------|
+| Application-level mutex | Single point of failure, doesn't scale across instances |
+| Redis distributed lock | Adds infrastructure dependency to critical path |
+| Queue-based serialization | Higher latency for the booking flow |
+
+## Scope
+
+**Applies to:**
+- c3-3 (row-level locking in event service repository) and c3-4 (booking creation orchestration)
+
+**Does NOT apply to:**
+- Read operations or non-availability updates
+
+## Override
+
+To override this ref:
+1. Document justification in an ADR under "Pattern Overrides"
+2. Cite this ref and explain why the override is necessary
+3. Specify the scope of the override (which components deviate)
+
+## Cited By
+
+- c3-302, c3-311, c3-410

--- a/.c3/refs/ref-data-shape-mapping.md
+++ b/.c3/refs/ref-data-shape-mapping.md
@@ -1,0 +1,59 @@
+---
+id: ref-data-shape-mapping
+c3-version: 4
+title: data-shape-mapping
+goal: Define the transformation rules between API response types and frontend display types
+scope: [c3-1, c3-6]
+---
+
+# data-shape-mapping
+
+## Goal
+
+Define the transformation rules between API response types and frontend display types.
+
+## Choice
+
+Backend returns snake_case JSON with prices in cents. Frontend transforms to camelCase with prices in dollars. Transformation happens in a dedicated transformer layer (`lib/api/transformers.ts`).
+
+## Why
+
+Backend follows Go/protobuf conventions (snake_case). Frontend follows TypeScript conventions (camelCase). Cents avoid floating-point issues in financial calculations. Dedicated transformer layer keeps conversion logic centralized and testable.
+
+## How
+
+| Guideline | Example |
+|-----------|---------|
+| Prices: cents to dollars | `price_cents: 5000` becomes `price: 50.00` (divide by 100) |
+| Fields: snake_case to camelCase | `image_url` becomes `image`, `available_quantity` becomes `available` |
+| Dates: RFC3339 to formatted | `2026-03-15T19:00:00Z` becomes `"March 15, 2026, 7:00 PM"` |
+| Raw types in `types.ts` | `ApiEvent`, `ApiBooking`, `ApiTicketTier` (match backend JSON) |
+| Transformed types in `types.ts` (lib) | `Event`, `PurchasedTicket`, `TicketTier` (frontend display) |
+| Transformer functions | `transformEvent()`, `transformBookingToTicket()` |
+
+## Not This
+
+| Alternative | Rejected Because |
+|-------------|------------------|
+| Backend returns frontend-friendly format | Couples backend to frontend, violates service independence |
+| Transform inline in components | Duplicates logic, easy to miss conversions |
+| Shared schema generation | Adds build-time complexity for limited benefit |
+
+## Scope
+
+**Applies to:**
+- c3-6 (transformer layer) and c3-1 (defines the API shape)
+
+**Does NOT apply to:**
+- Backend inter-service communication (protobuf handles that)
+
+## Override
+
+To override this ref:
+1. Document justification in an ADR under "Pattern Overrides"
+2. Cite this ref and explain why the override is necessary
+3. Specify the scope of the override (which components deviate)
+
+## Cited By
+
+- c3-604, c3-111, c3-112

--- a/.c3/refs/ref-grpc-service-structure.md
+++ b/.c3/refs/ref-grpc-service-structure.md
@@ -1,0 +1,61 @@
+---
+id: ref-grpc-service-structure
+c3-version: 4
+title: grpc-service-structure
+goal: Enforce consistent Go microservice layout across all backend services
+scope: [c3-1, c3-2, c3-3, c3-4, c3-5]
+---
+
+# grpc-service-structure
+
+## Goal
+
+Enforce consistent Go microservice layout across all backend services.
+
+## Choice
+
+Standard directory layout — `cmd/main.go`, `internal/{domain,repository,service,grpc,kafka}`, `migrations/`, `Dockerfile`, `go.mod` with replace directive. Go workspace (`go.work`) links all modules.
+
+## Why
+
+Consistent structure reduces cognitive load when switching between services, enables shared tooling (Makefile targets), and ensures each service is independently deployable with its own migrations.
+
+## How
+
+| Guideline | Example |
+|-----------|---------|
+| Entry point at `cmd/main.go` | Bootstraps config, DB pool, gRPC server |
+| Domain models in `internal/domain/` | `booking.go`, `event.go` — pure structs, no DB deps |
+| Repository interface + impl in `internal/repository/` | `booking_repository.go` (interface) + `postgres_booking_repository.go` (PGX) |
+| Business logic in `internal/service/` | `booking_service.go` — orchestrates domain + repo |
+| gRPC handlers in `internal/grpc/` | `server.go` — implements protobuf service interface |
+| Kafka integration in `internal/kafka/` | `producer.go` or `consumer.go` |
+| Migrations at `migrations/` | golang-migrate format: `000001_init.up.sql` / `000001_init.down.sql` |
+| Replace directive in go.mod | `replace github.com/ticketbox/pkg => ../../pkg` |
+
+## Not This
+
+| Alternative | Rejected Because |
+|-------------|------------------|
+| Monorepo single binary | Cannot scale services independently |
+| Flat package structure | Mixes concerns, harder to test |
+| External domain package | Domain is service-specific, not shared |
+
+## Scope
+
+**Applies to:**
+- c3-2, c3-3, c3-4, c3-5 (all gRPC services: user, event, booking, notification)
+
+**Does NOT apply to:**
+- Gateway (c3-1) follows a variant with `internal/{handler,middleware,router}` instead of `internal/{domain,repository,service,grpc}`
+
+## Override
+
+To override this ref:
+1. Document justification in an ADR under "Pattern Overrides"
+2. Cite this ref and explain why the override is necessary
+3. Specify the scope of the override (which components deviate)
+
+## Cited By
+
+- c3-201, c3-301, c3-401, c3-501, c3-101, c3-704, c3-705

--- a/.c3/refs/ref-jwt-auth-flow.md
+++ b/.c3/refs/ref-jwt-auth-flow.md
@@ -1,0 +1,59 @@
+---
+id: ref-jwt-auth-flow
+c3-version: 4
+title: jwt-auth-flow
+goal: Enforce consistent JWT-based authentication across frontend and backend
+scope: [c3-1, c3-2, c3-6]
+---
+
+# jwt-auth-flow
+
+## Goal
+
+Enforce consistent JWT-based authentication across frontend and backend.
+
+## Choice
+
+Stateless JWT with access+refresh token pair. User Service generates tokens, Gateway validates on every request, Frontend stores in localStorage and auto-refreshes on 401. Redis blacklist for logout.
+
+## Why
+
+Stateless auth scales horizontally without shared session store. Refresh tokens enable short-lived access tokens (security) without frequent re-login (UX). Redis blacklist handles logout without making JWTs stateful.
+
+## How
+
+| Guideline | Example |
+|-----------|---------|
+| User Service generates both tokens | `access_token` (short TTL) + `refresh_token` (long TTL) |
+| Gateway validates JWT on protected routes | Middleware extracts and verifies token, sets user context |
+| Gateway checks Redis blacklist | Rejected tokens return 401 immediately |
+| Frontend stores tokens in localStorage | `access_token` and `refresh_token` keys |
+| Frontend auto-refreshes on 401 | Intercepts 401, calls refresh endpoint, retries original request |
+| Logout blacklists token in Redis | Gateway adds token to Redis with TTL matching token expiry |
+
+## Not This
+
+| Alternative | Rejected Because |
+|-------------|------------------|
+| Session-based auth | Requires shared session store, doesn't scale as well |
+| OAuth2/OIDC | Overkill for single-app platform, adds complexity |
+| Cookie-based tokens | Cross-origin complications with microservices |
+
+## Scope
+
+**Applies to:**
+- c3-1 (gateway middleware), c3-2 (token generation), c3-6 (client-side token management)
+
+**Does NOT apply to:**
+- Service-to-service gRPC calls (trusted internal network)
+
+## Override
+
+To override this ref:
+1. Document justification in an ADR under "Pattern Overrides"
+2. Cite this ref and explain why the override is necessary
+3. Specify the scope of the override (which components deviate)
+
+## Cited By
+
+- c3-102, c3-110, c3-210, c3-601, c3-602, c3-614

--- a/.c3/refs/ref-mock-data-fallback.md
+++ b/.c3/refs/ref-mock-data-fallback.md
@@ -1,0 +1,57 @@
+---
+id: ref-mock-data-fallback
+c3-version: 4
+title: mock-data-fallback
+goal: Enable frontend development and demo without a running backend
+scope: [c3-6]
+---
+
+# mock-data-fallback
+
+## Goal
+
+Enable frontend development and demo without a running backend.
+
+## Choice
+
+Frontend BookingProvider tries to fetch events from API, falls back to hardcoded mock data (`lib/mock-data.ts`) on failure. Mock data includes full venue layouts for realistic rendering.
+
+## Why
+
+Frontend development often proceeds independently of backend. Mock data fallback eliminates the need to run 13 Docker containers during UI work. Also useful for demos and testing.
+
+## How
+
+| Guideline | Example |
+|-----------|---------|
+| Fetch first, fallback second | BookingProvider tries API, catches error, uses mock |
+| Mock data matches frontend types | Mock events have same shape as transformed API responses |
+| Full venue layouts included | Concert arena and sports stadium with sections, rows, seats |
+| No mock auth | Auth pages require backend — mock only covers event browsing |
+
+## Not This
+
+| Alternative | Rejected Because |
+|-------------|------------------|
+| MSW (Mock Service Worker) | More setup, overkill for simple data fallback |
+| Docker-compose for frontend devs | Heavy dependency, slow startup |
+| Static JSON files | Less flexible than TypeScript objects with types |
+
+## Scope
+
+**Applies to:**
+- c3-6 (BookingProvider only)
+
+**Does NOT apply to:**
+- Auth flow or backend services
+
+## Override
+
+To override this ref:
+1. Document justification in an ADR under "Pattern Overrides"
+2. Cite this ref and explain why the override is necessary
+3. Specify the scope of the override (which components deviate)
+
+## Cited By
+
+- c3-603

--- a/.c3/refs/ref-outbox-pattern.md
+++ b/.c3/refs/ref-outbox-pattern.md
@@ -1,0 +1,57 @@
+---
+id: ref-outbox-pattern
+c3-version: 4
+title: outbox-pattern
+goal: Ensure reliable async event publishing without dual-write problems
+scope: [c3-4, c3-5]
+---
+
+# outbox-pattern
+
+## Goal
+
+Ensure reliable async event publishing without dual-write problems.
+
+## Choice
+
+Booking Service writes booking record AND outbox event in the same database transaction. A separate process publishes outbox events to Kafka. Notification Service consumes from Kafka.
+
+## Why
+
+Writing to the database and Kafka in the same operation risks inconsistency (one succeeds, other fails). The outbox pattern ensures atomicity: if the booking is committed, the event is guaranteed to be published eventually.
+
+## How
+
+| Guideline | Example |
+|-----------|---------|
+| Outbox table in booking DB | `outbox(id, event_type, payload, published_at)` |
+| Same transaction | `BEGIN; INSERT booking; INSERT outbox; COMMIT;` |
+| Publisher reads unpublished | Polls outbox for `published_at IS NULL`, publishes to Kafka |
+| Consumer processes idempotently | Notification Service handles duplicate deliveries |
+
+## Not This
+
+| Alternative | Rejected Because |
+|-------------|------------------|
+| Direct Kafka publish in transaction | Dual-write problem — DB commits but Kafka fails |
+| Saga pattern | Overkill for notification side-effect |
+| CDC (Debezium) | Infrastructure complexity for simple use case |
+
+## Scope
+
+**Applies to:**
+- c3-4 (outbox writes in booking service) and c3-5 (Kafka consumption in notification service)
+
+**Does NOT apply to:**
+- User or event services which don't use the outbox
+
+## Override
+
+To override this ref:
+1. Document justification in an ADR under "Pattern Overrides"
+2. Cite this ref and explain why the override is necessary
+3. Specify the scope of the override (which components deviate)
+
+## Cited By
+
+- c3-402, c3-410, c3-501, c3-510, c3-703

--- a/.c3/refs/ref-repository-pattern.md
+++ b/.c3/refs/ref-repository-pattern.md
@@ -1,0 +1,57 @@
+---
+id: ref-repository-pattern
+c3-version: 4
+title: repository-pattern
+goal: Separate data access from business logic with interface-based repositories
+scope: [c3-2, c3-3, c3-4, c3-5]
+---
+
+# repository-pattern
+
+## Goal
+
+Separate data access from business logic with interface-based repositories.
+
+## Choice
+
+Go interface in `repository/` defining operations + PostgreSQL implementation using PGX in `postgres_*.go`. Services depend on the interface, not the implementation.
+
+## Why
+
+Enables testing with mocks, isolates PostgreSQL-specific code, and makes it possible to swap storage backends without changing business logic.
+
+## How
+
+| Guideline | Example |
+|-----------|---------|
+| Interface file: `{entity}_repository.go` | Defines CRUD operations as Go interface |
+| Implementation: `postgres_{entity}_repository.go` | PGX-based, receives `*pgxpool.Pool` |
+| Service receives interface | `NewBookingService(repo BookingRepository)` |
+| Transactions via pool | `pool.BeginTx(ctx, pgx.TxOptions{})` for multi-step ops |
+
+## Not This
+
+| Alternative | Rejected Because |
+|-------------|------------------|
+| ORM (GORM, Ent) | Overhead for simple queries, less control over locking |
+| Direct SQL in service | Mixes concerns, harder to test |
+| Generic repository | Go generics add complexity without clear benefit here |
+
+## Scope
+
+**Applies to:**
+- All services with databases (c3-2, c3-3, c3-4, c3-5)
+
+**Does NOT apply to:**
+- Gateway (c3-1) which has no database
+
+## Override
+
+To override this ref:
+1. Document justification in an ADR under "Pattern Overrides"
+2. Cite this ref and explain why the override is necessary
+3. Specify the scope of the override (which components deviate)
+
+## Cited By
+
+- c3-202, c3-302, c3-310, c3-402, c3-411, c3-502, c3-211

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 *.pen
 c3
+.claude/
+c3-nav.vsix

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 *.pen
+c3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,3 +76,11 @@ The critical path: Booking Service → Event Service `UpdateTicketAvailability` 
 ### Data Shape Mapping
 
 Backend returns `price_cents` (int64), `image_url`, `available_quantity`, `total_amount_cents`. Frontend expects `price` (number, dollars), `image`, `available`, `totalPrice`. Transformers in `lib/api/transformers.ts` handle all conversions.
+
+## Architecture Docs (C3)
+
+This project uses C3 docs in `.c3/`.
+For architecture questions, changes, audits, file context → `/c3`.
+Operations: query, audit, change, ref, sweep.
+File lookup: `c3x lookup <file-or-glob>` maps files/directories to components + refs.
+Code-map coverage: 100% of source files mapped to components.


### PR DESCRIPTION
## Summary
- Connect Next.js frontend to Go gRPC gateway with API client, JWT auth (auto-refresh on 401), and proxy rewrites
- Add login/register pages, auth context, and protected routes (my-tickets, checkout)
- Transform backend data shapes (snake_case/cents) to frontend types (camelCase/dollars) with dedicated transformers
- Generate dynamic SVG venue seat maps from API tier data
- Add mock data fallback for offline frontend development
- Add comprehensive README, CLAUDE.md docs, and C3 architecture documentation
- Add backend seed script and integration plan

## Test plan
- [ ] Verify `make up` starts all 13 containers and `make migrate` succeeds
- [ ] Test login/register flows against running backend
- [ ] Verify event listing and detail pages load data from API
- [ ] Test seat selection and checkout flow end-to-end
- [ ] Confirm mock data fallback works when backend is offline
- [ ] Run `npm run build` and `npm run lint` for frontend
- [ ] Run `make test` for backend services

🤖 Generated with [Claude Code](https://claude.com/claude-code)